### PR TITLE
Fixed TypeError caused by naming mistake in LSTM network.

### DIFF
--- a/src/architecture/architect.js
+++ b/src/architecture/architect.js
@@ -224,18 +224,18 @@ var architect = {
       // Input to all memory cells
       if (options.inputToDeep && i > 0) {
         let input = inputLayer.connect(memoryCell, methods.connection.ALL_TO_ALL);
-        inputGate.gate(input, methods.Gating.INPUT);
+        inputGate.gate(input, methods.gating.INPUT);
       }
 
       // Optional connections
       if (options.memoryToMemory) {
         let input = memoryCell.connect(memoryCell, methods.connection.ALL_TO_ELSE);
-        inputGate.gate(input, methods.Gating.INPUT);
+        inputGate.gate(input, methods.gating.INPUT);
       }
 
       if (options.outputToMemory) {
         let input = outputLayer.connect(memoryCell, methods.connection.ALL_TO_ALL);
-        inputGate.gate(input, methods.Gating.INPUT);
+        inputGate.gate(input, methods.gating.INPUT);
       }
 
       if (options.outputToGates) {


### PR DESCRIPTION
Found this small issue when testing an LSTM network with NEAT in node js.
Quite a simple one so i just fixed it on the spot.