### PR TITLE
Minor typo in the doc : Added a line return so the list is shown properly

### DIFF
--- a/mkdocs/templates/docs/builtins/narx.md
+++ b/mkdocs/templates/docs/builtins/narx.md
@@ -13,6 +13,7 @@ var network = new architect.NARX(inputSize, hiddenLayers, outputSize, previousIn
 ```
 
 A quick explanation of each argument:
+
 * `inputSize`: the amount of input nodes
 * `hiddenLayers`: an array containing hidden layer sizes, e.g. `[10,20,10]`. If only one hidden layer, can be a number (of nodes)
 * `outputSize`: the amount of output nodes


### PR DESCRIPTION
Added a line return so the list is shown properly.

