### PR TITLE
Reversing Sort Order in NEAT

### DIFF
--- a/dist/neataptic.js
+++ b/dist/neataptic.js
@@ -2784,7 +2784,7 @@ Neat.prototype = {
    */
   sort: function () {
     this.population.sort(function (a, b) {
-      return b.score - a.score;
+      return a.score - b.score;
     });
   },
 

--- a/src/neat.js
+++ b/src/neat.js
@@ -158,7 +158,7 @@ Neat.prototype = {
    */
   sort: function () {
     this.population.sort(function (a, b) {
-      return b.score - a.score;
+      return a.score - b.score;
     });
   },
 


### PR DESCRIPTION
### Potentially bug (or maybe I'm just confused): 
Typically, your fitness function is a function which strives to achieve the minimum value.  Why is this?  Because you often want to use well known algorithms such as Euclidean distance, Manhattan distance, absolute difference, sum of absolute difference squared, etc, to determine how close your gene is to an expected value.  

For example, here is a typical sum of absolute difference fitness function:
```
new neataptic.Neat(1, 1, async function(network) {
  const results = [
    await network.activate([1]),
    await network.activate([0])
  ]
  const expected = [
    [1],
    [0]
  ]
  const diff = results.map(function(result, i) {
    return Math.abs(this[i][0] - result[0])
  }, expected)
  const sum = diff.reduce((sum, v) => sum + v, 0);
  return sum;
})
```

It makes sense to use the minimum for the fitness function instead of the maximum.

### Fix
Reverse the sort order.