### PR TITLE
Control population complexity in NEAT evolution PR

### DIFF
--- a/src/neat.js
+++ b/src/neat.js
@@ -4,6 +4,7 @@ module.exports = Neat;
 /* Import */
 var Network = require('./architecture/network');
 var methods = require('./methods/methods');
+var config = require('./config');
 
 /* Easier variable naming */
 var selection = methods.selection;
@@ -39,6 +40,16 @@ function Neat (input, output, fitness, options) {
   this.mutation = options.mutation || methods.mutation.FFW;
 
   this.template = options.network || false;
+
+
+  this.maxNodes = options.maxNodes || Infinity;
+  this.maxConns = options.maxConns || Infinity;
+  this.maxGates = options.maxGates || Infinity;          
+
+  //allow usage of custom mutations selection method.
+  //the method is bound to "this" context so it can access the configured mutations list through "this.mutation"
+  this.mutationMethodSelect = typeof options.mutationMethodSelect == 'function' ? options.mutationMethodSelect.bind(this) : this.mutationMethodRandomSelect;
+
 
   // Generation counter
   this.generation = 0;
@@ -124,6 +135,31 @@ Neat.prototype = {
   },
 
   /**
+   * Selects a random mutation method for a given population and ensure that maxNodes, maxConns and maxGates are not exceeded.
+   */
+  mutationMethodRandomSelect: function(population) {
+    var mutationMethod = this.mutation[Math.floor(Math.random() * this.mutation.length)];
+
+    if (mutationMethod == methods.mutation.ADD_NODE && population.nodes.length >= this.maxNodes) {
+      if (config.warnings) console.warn('maxNodes exceeded!');
+      return null;
+    }
+
+    if (mutationMethod == methods.mutation.ADD_CONN && population.connections.length >= this.maxConns) {
+      if (config.warnings) console.warn('maxConns exceeded!');
+      return null;
+    }
+
+    if (mutationMethod == methods.mutation.ADD_GATE && population.gates.length >= this.maxGates) {
+      if (config.warnings) console.warn('maxGates exceeded!');
+      return null;
+    }
+
+
+    return mutationMethod;
+  },
+
+  /**
    * Mutates the given (or current) population
    */
   mutate: function () {
@@ -131,7 +167,7 @@ Neat.prototype = {
     for (var i = 0; i < this.population.length; i++) {
       if (Math.random() <= this.mutationRate) {
         for (var j = 0; j < this.mutationAmount; j++) {
-          var mutationMethod = this.mutation[Math.floor(Math.random() * this.mutation.length)];
+          var mutationMethod = this.mutationMethodSelect(this.population[i]);
           this.population[i].mutate(mutationMethod);
         }
       }


### PR DESCRIPTION
(ref. https://github.com/wagenaartje/neataptic/issues/61 )

This PR adds four new options to Neat constructor

 * maxNodes, maxConns and maxGates :  designate the maximum number of nodes, connections and gates per population (by default all those are set to Infinity)
 * mutationMethodSelect : allows the user to finetune mutations methods selection if he need more control over it, by default it use a random selection but controls the values above.

**Simple usage example :** 

```
// this define a 4 inputs / one output Neat , each population will have a maximum of 20 nodes, 100 connections and 2 gates.

var var Mutation = neataptic.methods.mutation;
//... 
  neat = new neataptic.Neat(4, 1, Selection.FITNESS_PROPORTIONATE,
    {		
      mutation: Mutation.ALL,

	  maxNodes:20,
	  maxConns:100,
	  maxGates:2,
	  
      popsize: POPULATION,
      mutationRate: MUTATION_RATE,
      elitism: Math.round(ELITISM_PERCENT * POPULATION),
      network: new Architect.Random(4, 1, 1)	  
    }
```


**Advanced usage example**

```
// Same as above except that we add a custom mutation selection


function myMutationSelection(population) {


	//if we have less than 8 nodes, try to add a new one 
        //this is maybe useless in a real context Neat algorithm, it's just a usage illustration :)
	if (population.nodes.length < 8) {
		console.log("Force ADD_NODE");
		return Mutation.ADD_NODE;
	}
	
	//otherwise fallback to default select mutation
	else return this.mutationMethodRandomSelect(population);
	  
}


//... 
  neat = new neataptic.Neat(4, 1, Selection.FITNESS_PROPORTIONATE,
    {		
      mutation: Mutation.ALL,

	  maxNodes:20,
	  maxConns:100,
	  maxGates:2,
	  
          mutationMethodSelect: myMutationSelection,

      popsize: POPULATION,
      mutationRate: MUTATION_RATE,
      elitism: Math.round(ELITISM_PERCENT * POPULATION),
      network: new Architect.Random(4, 1, 1)	  
    }
```


