### PR TITLE
efficientMutation flag for neat + XOR test case utilizing it

### DIFF
--- a/src/neat.js
+++ b/src/neat.js
@@ -38,6 +38,7 @@ function Neat (input, output, fitness, options) {
     methods.crossover.AVERAGE
   ];
   this.mutation = options.mutation || methods.mutation.FFW;
+  this.efficientMutation = options.efficientMutation || false;
 
   this.template = options.network || false;
 
@@ -135,7 +136,9 @@ Neat.prototype = {
    * Selects a random mutation method for a genome according to the parameters
    */
   selectMutationMethod: function (genome) {
-    var mutationMethod = this.mutation[Math.floor(Math.random() * this.mutation.length)];
+    var mutation = this.efficientMutation ? genome.getPossibleMutations(this.mutation) : this.mutation;
+
+    var mutationMethod = mutation[Math.floor(Math.random() * mutation.length)];
 
     if (mutationMethod === methods.mutation.ADD_NODE && genome.nodes.length >= this.maxNodes) {
       if (config.warnings) console.warn('maxNodes exceeded!');

--- a/test/neat.js
+++ b/test/neat.js
@@ -81,4 +81,27 @@ describe('Neat', function () {
 
     assert.isBelow(results.error, 0.03);
   });
+  it('XOR using efficientMutation', async function () {
+    this.timeout(40000);
+    // Train the XOR gate
+    var trainingSet = [
+      { input: [0, 0], output: [0] },
+      { input: [0, 1], output: [1] },
+      { input: [1, 0], output: [1] },
+      { input: [1, 1], output: [0] }
+    ];
+
+    var network = new Network(2, 1);
+    var results = await network.evolve(trainingSet, {
+      mutation: methods.mutation.FFW,
+      equal: true,
+      elitism: 10,
+      mutationRate: 0.5,
+      error: 0.03,
+      efficientMutation: true,
+      threads: 1
+    });
+
+    assert.isBelow(results.error, 0.03);
+  });
 });


### PR DESCRIPTION
Implements an efficientMutation flag that can now be passed in as a boolean option. Before it attempts to do any mutations, it checks which mutations are possible on the genome from the selected mutation types, and passes . There shouldn't be a case where no mutations are returned (as long as one of ADD_NODE, MOD_WEIGHT, MOD_BIAS, is amongst the selected mutations, and maxNodes isn't enabled).

So far it appears to provide more consistent results and solutions in less generations than without, from limited testing. Some benchmarks may be useful as well, this will likely see more benefit on larger datasets. 

The efficient can be a misnomer, as the flag will use additional computational resources than without, but it's a tradeoff to avoid wasting mutations and creating more diverse generations.

Tested both with `evolve` and custom evaluations using fitness function.

