### PR TITLE
patches multithreaded cross-entropy scoring issue

### DIFF
--- a/src/architecture/network.js
+++ b/src/architecture/network.js
@@ -907,7 +907,7 @@ Network.prototype = {
             var genome = queue.shift();
 
             worker.evaluate(genome).then(function (result) {
-              genome.score = -result;
+              genome.score = isNaN(parseFloat(result)) ? -Infinity : -result;
               genome.score -= (genome.nodes.length - genome.input - genome.output +
                 genome.connections.length + genome.gates.length) * growth;
               genome.score = isNaN(genome.score) ? -Infinity : genome.score;


### PR DESCRIPTION
Quick fix to the scoring issue encountered when using workers. There may be a deeper fix needed, as the cross entropy function appears to like returning `null`, and preceding the `null` with the negative sign, basically casts it to 0, hence reaching 0 error in the first/second generation.