### PR TITLE
skip elitist genomes when mutate()ing

### DIFF
--- a/src/neat.js
+++ b/src/neat.js
@@ -160,7 +160,7 @@ Neat.prototype = {
    */
   mutate: function () {
     // Elitist genomes should not be included
-    for (var i = 0; i < this.population.length; i++) {
+    for (var i = this.elitism; i < this.population.length; i++) {
       if (Math.random() <= this.mutationRate) {
         for (var j = 0; j < this.mutationAmount; j++) {
           var mutationMethod = this.selectMutationMethod(this.population[i]);


### PR DESCRIPTION
PR for:
mutate() must skip elitist genomes #160

[](https://github.com/wagenaartje/neataptic/issues/160)

1 row patch  for mutate() to skip elitist genomes
